### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: PHP Unit Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/kriollo/versa-orm/security/code-scanning/1](https://github.com/kriollo/versa-orm/security/code-scanning/1)

To fix the issue, add a `permissions` block specifying minimal required permissions for the workflow. Since the workflow only checks out code, runs unit tests, and uploads artifacts, the job does not require write access to repository contents or any other resources. The recommended approach is to set `permissions: contents: read` at the root level of the workflow, ensuring all jobs start with restrictive permissions unless explicitly granted more. This will help adhere to security best practices and limit the potential impact in case of a workflow compromise.

**Steps to fix:**  
- In `.github/workflows/phpunit.yml`, add the following block at the top (immediately after the `name:`), before `on:`:
  ```yaml
  permissions:
    contents: read
  ```
This ensures all jobs in this workflow only receive read-only repository access by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
