### PR TITLE
test(unit): add unit tests skeletons

### DIFF
--- a/phpunit-sqlite.xml
+++ b/phpunit-sqlite.xml
@@ -14,6 +14,7 @@
         <!-- All tests suite - using directory to avoid duplication -->
         <testsuite name="All">
             <directory>./testSQLite</directory>
+            <directory>./tests/unit</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.unit.xml
+++ b/phpunit.unit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="testSQLite/bootstrap.php"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true">
+
+  <testsuites>
+    <testsuite name="Unit Tests">
+      <directory>./tests/unit</directory>
+    </testsuite>
+  </testsuites>
+
+  <php>
+    <env name="PHPUNIT_RUNNING" value="1"/>
+  </php>
+
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,8 @@
 
   <testsuites>
     <testsuite name="VersaORM SQLite Test Suite">
-      <directory>./testSQLite</directory>
+  <directory>./testSQLite</directory>
+  <directory>./tests/unit</directory>
     </testsuite>
   </testsuites>
 

--- a/tests/unit/DialectsTest.php
+++ b/tests/unit/DialectsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VersaORM\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use VersaORM\SQL\Dialects\MySQLDialect;
+use VersaORM\SQL\Dialects\PostgreSQLDialect;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+class DialectsTest extends TestCase
+{
+    public function testMySQLQuoteIdentifier(): void
+    {
+        $d = new MySQLDialect();
+
+        self::assertSame('`id`', $d->quoteIdentifier('id'));
+        self::assertSame('`table`.*', $d->quoteIdentifier('table.*'));
+        self::assertSame('*', $d->quoteIdentifier('*'));
+    }
+
+    public function testPostgresQuoteIdentifier(): void
+    {
+        $d = new PostgreSQLDialect();
+
+        self::assertSame('"id"', $d->quoteIdentifier('id'));
+        self::assertSame('"table".*', $d->quoteIdentifier('table.*'));
+        self::assertSame('*', $d->quoteIdentifier('*'));
+    }
+
+    public function testCompileLimitOffsetAndPlaceholder(): void
+    {
+        $m = new MySQLDialect();
+        $p = new PostgreSQLDialect();
+
+        self::assertSame('?', $m->placeholder(1));
+        self::assertSame('?', $p->placeholder(2));
+
+        self::assertSame(' LIMIT 10 OFFSET 5', $m->compileLimitOffset(10, 5));
+        self::assertSame(' LIMIT 10', $m->compileLimitOffset(10, null));
+        self::assertSame('', $m->compileLimitOffset(null, null));
+    }
+}

--- a/tests/unit/HandlesErrorsBehaviorTest.php
+++ b/tests/unit/HandlesErrorsBehaviorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VersaORM\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use VersaORM\VersaORMException;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Clase mínima que usa el trait para probar su comportamiento aislado
+class MinimalModelForErrorHandling
+{
+    use \VersaORM\Traits\HandlesErrors;
+
+    // Simular getTable y save/store/update/delete/find para pruebas mínimas
+    public function getTable(): string
+    {
+        return 'minimal';
+    }
+
+    public function save()
+    {
+        // Simular excepción para comprobar withErrorHandling
+        throw new VersaORMException('simulated', 'SIMULATED_ERROR');
+    }
+
+    public function store()
+    {
+        return true;
+    }
+
+    public function update(array $data)
+    {
+        return true;
+    }
+
+    public function delete()
+    {
+        return true;
+    }
+
+    public static function find($id)
+    {
+        return null;
+    }
+
+    // Wrappers públicos para pruebas que exponen comportamiento protegido
+    public function _validateBeforeOperation(string $op): bool
+    {
+        return $this->validateBeforeOperation($op);
+    }
+
+    public function _handleModelErrorForTest(VersaORMException $e): mixed
+    {
+        return $this->handleModelError($e, []);
+    }
+}
+
+class HandlesErrorsBehaviorTest extends TestCase
+{
+    public function testConfigureAndGetLastErrorInitial(): void
+    {
+        $m = new MinimalModelForErrorHandling();
+
+        // No hay errores inicialmente
+        self::assertFalse($m->hasError());
+        self::assertNull($m->getLastError());
+
+        // Configurar para no lanzar excepciones al manejar errores
+        MinimalModelForErrorHandling::configureErrorHandling(['throw_on_error' => false, 'format_for_api' => false]);
+
+        // Llamar safeSave que internamente lanzará y será manejado
+        $res = $m->safeSave();
+
+        // Como throw_on_error=false, safeSave debe retornar null y haber registrado lastError
+        self::assertNull($res);
+        self::assertTrue($m->hasError());
+        self::assertIsArray($m->getLastError());
+        self::assertArrayHasKey('error', $m->getLastError());
+    }
+
+    public function testValidateBeforeOperationEmptyAttributes(): void
+    {
+        $m = new MinimalModelForErrorHandling();
+
+        // Atributos vacíos => validateBeforeOperation('save') debe fallar y retornar false
+        $valid = $m->_validateBeforeOperation('save');
+
+        self::assertFalse($valid);
+        self::assertTrue($m->hasError());
+        self::assertSame('EMPTY_ATTRIBUTES', $m->getLastErrorCode());
+    }
+}

--- a/tests/unit/HandlesErrorsTest.php
+++ b/tests/unit/HandlesErrorsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VersaORM\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+class HandlesErrorsTest extends TestCase
+{
+    public function testTraitIsAvailable(): void
+    {
+        self::assertTrue(trait_exists('\\VersaORM\\Traits\\HandlesErrors') || trait_exists('\\VersaORM\\Traits\\VersaORMTrait'));
+    }
+}

--- a/tests/unit/SQLDialectTest.php
+++ b/tests/unit/SQLDialectTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VersaORM\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+class SQLDialectTest extends TestCase
+{
+    public function testDialectClassExists(): void
+    {
+        self::assertTrue(class_exists('\\VersaORM\\SQL\\Dialects\\MySQLDialect') || class_exists('\\VersaORM\\SQL\\Dialects\\PostgreSQLDialect'));
+    }
+}

--- a/tests/unit/VersaModelMinimalTest.php
+++ b/tests/unit/VersaModelMinimalTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VersaORM\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+class VersaModelMinimalTest extends TestCase
+{
+    public function testModelClassExists(): void
+    {
+        self::assertTrue(class_exists('\\VersaORM\\VersaModel'));
+    }
+}

--- a/tests/unit/VersaORMTest.php
+++ b/tests/unit/VersaORMTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VersaORM\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+class VersaORMTest extends TestCase
+{
+    public function testCoreClassLoads(): void
+    {
+        self::assertTrue(class_exists('\\VersaORM\\VersaORM'));
+    }
+}


### PR DESCRIPTION
Añade tests esqueleto en tests/unit y un phpunit.unit.xml para ejecutar solo los unit tests. Esta PR contiene archivos iniciales para empezar a cubrir funciones transversales sin dependencia de BD.