### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI — Tests & Coverage
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/kriollo/versa-orm/security/code-scanning/4](https://github.com/kriollo/versa-orm/security/code-scanning/4)

The best way to fix the problem is to add an explicit `permissions` key to limit the GitHub Actions default token scope. In this case, since the job only checks out code, runs tests, uploads artifacts, and posts to Codecov (which uses its own external token), the minimum required GitHub permissions are `contents: read`. This block should be added either at the workflow root (recommended if all jobs in the workflow have the same requirement) or within the `phpunit-coverage` job. To centralize and future-proof this workflow, adding the following at the root (below the `name:` and before `on:`) ensures correct defaults:  
```yaml
permissions:
  contents: read
```
No changes to other methods, definitions, or imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
